### PR TITLE
fix: correctly pass internal temp to db insert

### DIFF
--- a/db.py
+++ b/db.py
@@ -22,13 +22,13 @@ except mariadb.Error as e:
 # Close database connection on exit
 atexit.register(conn.close)
 
-def writeMeasurement(temperature_f, humidity, internal_temperature_f, internal_humidity, snowDepth):
+def writeMeasurement(temp, humidity, internal_temp, internal_humidity, snowDepth):
   try:
     # Get Cursor
     cur = conn.cursor()
     cur.execute(
-    f"INSERT INTO {tableName} (temp,humidity,internal_temperature_f,internal_humidity,snow_depth) VALUES (?, ?, ?)",
-    (temperature_f, humidity, internal_temp, internal_humidity, snowDepth))
+    f"INSERT INTO {tableName} (temp,humidity,internal_temp,internal_humidity,snow_depth) VALUES (?, ?, ?, ?, ?)",
+    (temp, humidity, internal_temp, internal_humidity, snowDepth))
     conn.commit() 
     print(f"Inserted new measurement: {cur.lastrowid}")
     cur.close()

--- a/tempAndHumidity.py
+++ b/tempAndHumidity.py
@@ -28,8 +28,4 @@ def getExternalTempAndHumidity():
   print("Humidity: %0.1f %%" % sensor.relative_humidity)
   humidity = sensor.relative_humidity
   temperature_f = sensor.temperature * (9 / 5) + 32
-
-  print(
-    "External Temp: {:.1f} F / {:.1f} C    Humidity: {}% ".format(temperature_f, humidity)
-  )
   return temperature_f, sensor.relative_humidity


### PR DESCRIPTION
Before not all the args were passed once DB columns were updated 